### PR TITLE
Rename packages to not clash with the official cecil package name

### DIFF
--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(ToolsFramework)</TargetFramework>
-    <PackageId>Mono.Cecil</PackageId>
+    <PackageId>Microsoft.DotNet.Cecil</PackageId>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/symbols/pdb/Mono.Cecil.Pdb.csproj
+++ b/symbols/pdb/Mono.Cecil.Pdb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(ToolsFramework)</TargetFramework>
-    <PackageId>Mono.Cecil.Pdb</PackageId>
+    <PackageId>Microsoft.DotNet.Cecil.Pdb</PackageId>
     <IsPackable>true</IsPackable>
     <NoWarn>0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>


### PR DESCRIPTION
Rename packages to not clash with the official cecil package name, Microsoft.DotNet.Cecil and Microsoft.DotNet.Cecil.Pdb are only internal packages