### PR TITLE
Allow overriding PackageId in Mono.Cecil.overrides

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\cecil.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
     <RootNamespace></RootNamespace>
+    <PackageId>$(MSBuildProjectName.Replace('Mono', 'Microsoft.DotNet'))</PackageId>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>

--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(ToolsFramework)</TargetFramework>
-    <PackageId>Microsoft.DotNet.Cecil</PackageId>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/symbols/pdb/Mono.Cecil.Pdb.csproj
+++ b/symbols/pdb/Mono.Cecil.Pdb.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(ToolsFramework)</TargetFramework>
-    <PackageId>Microsoft.DotNet.Cecil.Pdb</PackageId>
     <IsPackable>true</IsPackable>
     <NoWarn>0649</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>


### PR DESCRIPTION
This moves the PackageId definition to shared props which are imported before Mono.Cecil.overrides. This will allow dotnet/linker (which still builds cecil as a submodule) to produce a ref assembly package for illink that depends on the publicly available packages (Mono.Cecil, not Microsoft.DotNet.Cecil).