### PR TITLE
[release/7.0] Fix RVA field alignment (#60)

### DIFF
--- a/Mono.Cecil.Cil/CodeWriter.cs
+++ b/Mono.Cecil.Cil/CodeWriter.cs
@@ -32,7 +32,7 @@ namespace Mono.Cecil.Cil {
 		public CodeWriter (MetadataBuilder metadata)
 			: base (0)
 		{
-			this.code_base = metadata.text_map.GetNextRVA (TextSegment.CLIHeader);
+			this.code_base = metadata.text_map.GetRVA (TextSegment.Code);
 			this.metadata = metadata;
 			this.standalone_signatures = new Dictionary<uint, MetadataToken> ();
 			this.tiny_method_bodies = new Dictionary<ByteBuffer, RVA> (new ByteBufferEqualityComparer ());

--- a/Mono.Cecil/AssemblyWriter.cs
+++ b/Mono.Cecil/AssemblyWriter.cs
@@ -987,6 +987,11 @@ namespace Mono.Cecil {
 			var map = new TextMap ();
 			map.AddMap (TextSegment.ImportAddressTable, module.Architecture == TargetArchitecture.I386 ? 8 : 0);
 			map.AddMap (TextSegment.CLIHeader, 0x48, 8);
+			var pe64 = module.Architecture == TargetArchitecture.AMD64 || module.Architecture == TargetArchitecture.IA64 || module.Architecture == TargetArchitecture.ARM64;
+			// Alignment of the code segment must be set before the code is written
+			// These alignment values are probably not necessary, but are being left in
+			// for now in case something requires them.
+			map.AddMap (TextSegment.Code, 0, !pe64 ? 4 : 16);
 			return map;
 		}
 

--- a/Test/Mono.Cecil.Tests/FieldTests.cs
+++ b/Test/Mono.Cecil.Tests/FieldTests.cs
@@ -160,7 +160,7 @@ namespace Mono.Cecil.Tests {
 					var priv_impl = GetPrivateImplementationType (module);
 					Assert.IsNotNull (priv_impl);
 
-					Assert.AreEqual (6, priv_impl.Fields.Count);
+					Assert.AreEqual (8, priv_impl.Fields.Count);
 
 					foreach (var field in priv_impl.Fields)
 					{
@@ -170,7 +170,8 @@ namespace Mono.Cecil.Tests {
 						Assert.IsNotNull (field.InitialValue);
 
 						int rvaAlignment = AlignmentOfInteger (field.RVA);
-						int desiredAlignment = Math.Min(8, AlignmentOfInteger (field.InitialValue.Length));
+						var fieldType = field.FieldType.Resolve ();
+						int desiredAlignment = fieldType.PackingSize;
 						Assert.GreaterOrEqual (rvaAlignment, desiredAlignment);
 					}
 				}

--- a/Test/Resources/il/FieldRVAAlignment.il
+++ b/Test/Resources/il/FieldRVAAlignment.il
@@ -46,12 +46,22 @@
     .size 6
   } // end of class '__StaticArrayInitTypeSize=6'
 
+  .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=4Align=32'
+        extends [mscorlib]System.ValueType
+  {
+    .pack 32
+    .size 4
+  }
+
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=3' '$$method0x6000001-1' at I_000020F0
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=20' '$$method0x6000001-2' at I_000020F8
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=5' '$$method0x6000001-3' at I_00002108
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=20' '$$method0x6000001-4' at I_00002110
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=6' '$$method0x6000001-5' at I_00002120
   .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=16' '$$method0x6000001-6' at I_00002130
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=3' 'separator' at I_00002140
+  .field static assembly valuetype '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'/'__StaticArrayInitTypeSize=4Align=32' '32_align' at I_00002150
+
 } // end of class '<PrivateImplementationDetails>{9B33BB20-87EF-4094-9948-34882DB2F001}'
 
 
@@ -69,3 +79,7 @@
                  08 00 0C 00 0D 00) 
 .data cil I_00002130 = bytearray (
                  01 00 00 00 02 00 00 00 03 00 00 00 05 00 00 00) 
+.data cil I_00002140 = bytearray (
+                 01 02 03)
+.data cil I_00002150 = bytearray (
+                 01 02 03 04)


### PR DESCRIPTION
Backporting https://github.com/dotnet/cecil/pull/60 to the release/7.0 branch (which I created for this purpose, pointing at the commit currently referenced by the dotnet/linker 7.0 branch: https://github.com/dotnet/linker/tree/release/7.0/external).

This implements a cecil fix required to support the alignment requirements of the Roslyn `CreateSpan` support.

Fixes https://github.com/dotnet/runtime/issues/79477

## Customer Impact

Soon (once we ship a Roslyn that supports the CreateSpan APIs introduced in 7.0), trimmed 7.0 apps using the latest Roslyn may start crashing if they use constant arrays of `long` or `ulong` that are cast to `ReadOnlySpan<T>`. The failure mode we have observed is `ArgumentException` during `CreateSpan`. The crash happens if the constant data representing the array happens to be misaligned after trimming (which is likely, because the 7.0 trimmer did not respect the new alignment requirements).

Note that this hasn't actually been observed externally yet, but we anticipate that we will once the new Roslyn is shipped.

## Testing

- Cecil tests (including PEVerify of round-tripped assemblies on windows)
- Linker tests
- Manual validation of simple console apps on windows and linux.
- dotnet/runtime tests using a linker with the same fix in 8.0 (https://github.com/dotnet/runtime/pull/79449)
- The new Roslyn `CreateSpan` support is being used in https://github.com/dotnet/runtime/pull/79461, where we originally discovered the issue that this fixes. We will get validation of the same fix on 8.0 bits there.

We might want to wait to service this until we have released the fix in an 8.0 preview to get extra validation in the wild.

## Risk

Medium to high risk. This changes the alignment of the code section for all assemblies written by cecil on x64, and can also change the alignment of later sections, even for code which doesn't use `CreateSpan` helpers. The change is significant at the binary level, but we have no reason to believe that this will break anything downstream. If the binary change is problematic, we would expect to see catastrophic failures during the testing, but this was not the case. (An earlier incomplete fix _did_ result in catastrophic failures, validating this expectation).