### PR TITLE
Merge changes from upstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: dotnet test --no-build -c Debug Mono.Cecil.sln
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.2" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(MonoBuild)' != ''">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/Mono.Cecil.Tests.props
+++ b/Mono.Cecil.Tests.props
@@ -4,10 +4,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit">
-      <Version>3.11.0</Version>
+      <Version>3.14.0</Version>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter">
-      <Version>3.12.0</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2508,7 +2508,7 @@ namespace Mono.Cecil {
 
 			if (module.IsWindowsMetadata ())
 				foreach (var custom_attribute in custom_attributes)
-					WindowsRuntimeProjections.Project (owner, custom_attribute);
+					WindowsRuntimeProjections.Project (owner, custom_attributes, custom_attribute);
 
 			return custom_attributes;
 		}

--- a/Mono.Cecil/GenericParameter.cs
+++ b/Mono.Cecil/GenericParameter.cs
@@ -165,6 +165,11 @@ namespace Mono.Cecil {
 			set { attributes = attributes.SetAttributes ((ushort) GenericParameterAttributes.DefaultConstructorConstraint, value); }
 		}
 
+		public bool AllowByRefLikeConstraint {
+			get { return attributes.GetAttributes ((ushort) GenericParameterAttributes.AllowByRefLikeConstraint); }
+			set { attributes = attributes.SetAttributes ((ushort) GenericParameterAttributes.AllowByRefLikeConstraint, value); }
+		}
+
 		#endregion
 
 		public GenericParameter (IGenericParameterProvider owner)

--- a/Mono.Cecil/GenericParameterAttributes.cs
+++ b/Mono.Cecil/GenericParameterAttributes.cs
@@ -22,6 +22,7 @@ namespace Mono.Cecil {
 		SpecialConstraintMask			= 0x001c,
 		ReferenceTypeConstraint			= 0x0004,
 		NotNullableValueTypeConstraint	= 0x0008,
-		DefaultConstructorConstraint	= 0x0010
+		DefaultConstructorConstraint	= 0x0010,
+		AllowByRefLikeConstraint = 0x0020,
 	}
 }

--- a/Mono.Cecil/WindowsRuntimeProjections.cs
+++ b/Mono.Cecil/WindowsRuntimeProjections.cs
@@ -241,7 +241,7 @@ namespace Mono.Cecil {
 					treatment = TypeDefinitionTreatment.PrefixWindowsRuntimeName;
 
 				if (treatment == TypeDefinitionTreatment.PrefixWindowsRuntimeName || treatment == TypeDefinitionTreatment.NormalType)
-					if (!type.IsInterface && HasAttribute (type, "Windows.UI.Xaml", "TreatAsAbstractComposableClassAttribute"))
+					if (!type.IsInterface && HasAttribute (type.CustomAttributes, "Windows.UI.Xaml", "TreatAsAbstractComposableClassAttribute"))
 						treatment |= TypeDefinitionTreatment.Abstract;
 			}
 			else if (metadata_kind == MetadataKind.ManagedWindowsMetadata && IsClrImplementationType (type))
@@ -860,7 +860,7 @@ namespace Mono.Cecil {
 			throw new Exception ();
 		}
 
-		public static void Project (ICustomAttributeProvider owner, CustomAttribute attribute)
+		public static void Project (ICustomAttributeProvider owner, Collection<CustomAttribute> owner_attributes, CustomAttribute attribute)
 		{
 			if (!IsWindowsAttributeUsageAttribute (owner, attribute))
 				return;
@@ -876,7 +876,7 @@ namespace Mono.Cecil {
 			}
 
 			if (treatment == CustomAttributeValueTreatment.None) {
-				var multiple = HasAttribute (type, "Windows.Foundation.Metadata", "AllowMultipleAttribute");
+				var multiple = HasAttribute (owner_attributes, "Windows.Foundation.Metadata", "AllowMultipleAttribute");
 				treatment = multiple ? CustomAttributeValueTreatment.AllowMultiple : CustomAttributeValueTreatment.AllowSingle;
 			}
 
@@ -905,9 +905,9 @@ namespace Mono.Cecil {
 			return declaring_type.Name == "AttributeUsageAttribute" && declaring_type.Namespace == /*"Windows.Foundation.Metadata"*/"System";
 		}
 
-		static bool HasAttribute (TypeDefinition type, string @namespace, string name)
+		static bool HasAttribute (Collection<CustomAttribute> attributes, string @namespace, string name)
 		{
-			foreach (var attribute in type.CustomAttributes) {
+			foreach (var attribute in attributes) {
 				var attribute_type = attribute.AttributeType;
 				if (attribute_type.Name == name && attribute_type.Namespace == @namespace)
 					return true;

--- a/Mono.Security.Cryptography/CryptoService.cs
+++ b/Mono.Security.Cryptography/CryptoService.cs
@@ -26,6 +26,8 @@ namespace Mono.Cecil {
 
 	static class CryptoService {
 
+		static SHA1 CreateSHA1 () => new SHA1CryptoServiceProvider ();
+
 		public static byte [] GetPublicKey (WriterParameters parameters)
 		{
 			using (var rsa = parameters.CreateRSA ()) {
@@ -93,7 +95,7 @@ namespace Mono.Cecil {
 				+ (strong_name_directory.VirtualAddress - text.VirtualAddress));
 			var strong_name_length = (int) strong_name_directory.Size;
 
-			var sha1 = new SHA1Managed ();
+			var sha1 = CreateSHA1 ();
 			var buffer = new byte [buffer_size];
 			using (var crypto_stream = new CryptoStream (Stream.Null, sha1, CryptoStreamMode.Write)) {
 				stream.Seek (0, SeekOrigin.Begin);
@@ -131,7 +133,7 @@ namespace Mono.Cecil {
 		{
 			const int buffer_size = 8192;
 
-			var sha1 = new SHA1Managed ();
+			var sha1 = CreateSHA1 ();
 			var buffer = new byte [buffer_size];
 
 			using (var crypto_stream = new CryptoStream (Stream.Null, sha1, CryptoStreamMode.Write))
@@ -142,7 +144,7 @@ namespace Mono.Cecil {
 
 		public static byte [] ComputeHash (params ByteBuffer [] buffers)
 		{
-			var sha1 = new SHA1Managed ();
+			var sha1 = CreateSHA1 ();
 
 			using (var crypto_stream = new CryptoStream (Stream.Null, sha1, CryptoStreamMode.Write)) {
 				for (int i = 0; i < buffers.Length; i++) {

--- a/ProjectInfo.cs
+++ b/ProjectInfo.cs
@@ -15,6 +15,6 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible (false)]
 
-[assembly: AssemblyVersion ("0.11.4.0")]
-[assembly: AssemblyFileVersion ("0.11.4.0")]
-[assembly: AssemblyInformationalVersion ("0.11.4.0")]
+[assembly: AssemblyVersion ("0.11.5.0")]
+[assembly: AssemblyFileVersion ("0.11.5.0")]
+[assembly: AssemblyInformationalVersion ("0.11.5.0")]

--- a/Test/Mono.Cecil.Tests/ImageReadTests.cs
+++ b/Test/Mono.Cecil.Tests/ImageReadTests.cs
@@ -182,7 +182,7 @@ namespace Mono.Cecil.Tests {
 		[Test]
 		public void WindowsRuntimeComponentAssembly ()
 		{
-			var resolver = WindowsRuntimeAssemblyResolver.CreateInstance ();
+			var resolver = WindowsRuntimeAssemblyResolver.CreateInstance (applyWindowsRuntimeProjections: false);
 			if (resolver == null)
 				return;
 

--- a/Test/Resources/il/others.il
+++ b/Test/Resources/il/others.il
@@ -78,4 +78,29 @@
 		.other instance void Others::dang_Handler (class [mscorlib]System.EventHandler)
 		.other instance void Others::fang_Handler (class [mscorlib]System.EventHandler)
 	}
+
+	.method public static void OverloadedWithFpArg(method int32 *(int32) X) cil managed
+	{
+	    ret
+	}
+
+	.method public static void OverloadedWithFpArg(method int32 *(int64) X) cil managed
+	{
+	    ret
+	}
+
+	.method public static void OverloadedWithFpArg(method unmanaged cdecl int32 *(int32) X) cil managed
+	{
+	    ret
+	}
+
+	.method public instance void  SameMethodNameInstanceStatic() cil managed
+	{
+		ret
+	}
+
+	.method public static void  SameMethodNameInstanceStatic() cil managed
+	{
+		ret
+	} // end of static method MethodNameTests::MethodName
 }

--- a/Test/Resources/il/privatescope.il
+++ b/Test/Resources/il/privatescope.il
@@ -1,0 +1,77 @@
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89)
+  .ver 2:0:0:0
+}
+
+.assembly PrivateScope {}
+
+.module PrivateScope.dll
+
+.class private auto ansi Foo {
+
+  .method public specialname rtspecialname instance void .ctor () cil managed
+  {
+    ldarg.0
+    call instance void [mscorlib]System.Object::.ctor ()
+    ret
+  }
+
+  .method public instance void  CallSameNameMethods() cil managed
+  {
+    ldarg.0
+    call      instance void Foo::'SameName'()
+    ldarg.0
+    call      instance void Foo::'SameName$PST0600A3BA'()
+    ldarg.0
+    call      instance void Foo::'SameName$PST0600A3BC'()
+    ret
+  }
+
+ .method public hidebysig
+    instance void 'SameName' () cil managed
+  {
+    ret
+  }
+
+  .method privatescope
+    instance void 'SameName$PST0600A3BA' () cil managed
+  {
+    ret
+  }
+
+  .method privatescope
+    instance void 'SameName$PST0600A3BC' () cil managed
+  {
+    ret
+  }
+  
+  .method public instance void  CallSameNameMethodsGeneric() cil managed
+  {
+    ldarg.0
+    call      instance void Foo::'SameNameGeneric'<int32>()
+    ldarg.0
+    call      instance void Foo::'SameNameGeneric$PST0600A3BD'<int32>()
+    ldarg.0
+    call      instance void Foo::'SameNameGeneric$PST0600A3BE'<int32>()
+    ret
+  }
+
+ .method public hidebysig
+    instance void 'SameNameGeneric'<T> () cil managed
+  {
+    ret
+  }
+
+  .method privatescope
+    instance void 'SameNameGeneric$PST0600A3BD'<T> () cil managed
+  {
+    ret
+  }
+
+  .method privatescope
+    instance void 'SameNameGeneric$PST0600A3BE'<T> () cil managed
+  {
+    ret
+  }
+}


### PR DESCRIPTION
This brings in the latest cecil changes from upstream. Importantly, includes:
- Changes for ByRefLike constrains (needed for https://github.com/dotnet/runtime/issues/98519)
- Updates the version of NUnit that doesn't throw due to unknown framework version in some of our tests.
  - See https://github.com/dotnet/arcade/issues/14812 for context.
  - This is why I was seeing some test failures in https://github.com/jbevain/cecil/pull/947 but not https://github.com/dotnet/cecil/pull/183.