### PR TITLE
Update VersionPrefix

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- This repo version -->
     <!-- We need to modify the version here manually everytime the version changes from the upstream branch jbevain/cecil -->
-    <VersionPrefix>0.11.4.0</VersionPrefix>
+    <VersionPrefix>0.11.5.0</VersionPrefix>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <!-- Use VSTestRunner instead of allowing Arcade to use xunit, since Cecil tests are nunit based -->
     <UseVSTestRunner>true</UseVSTestRunner>


### PR DESCRIPTION
The updates from https://github.com/dotnet/cecil/pull/186 include a version bump from upstream, so we need to do the same.