### PR TITLE
Attempt to fix strong-name signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -13,6 +13,6 @@
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
   <ItemGroup>
-    <StrongNameSignInfo Include="CecilStrongName" PublicKeyToken="50cebf1cceb9d05e" CertificateName="3PartySHA2" />
+    <StrongNameSignInfo Include="$(MSBuildThisFileDirectory)..\cecil.snk" PublicKeyToken="50cebf1cceb9d05e" CertificateName="CecilStrongName" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Cecil assemblies aren't being strong-name signed. Hoping this fixes it. Not sure if there's a good way to test this locally since we public-sign the assemblies during the build, then do final strong-name signing in MicroBuild, from what I understand.