### PR TITLE
[release/9.0] Revert "Attempt to fix strong-name signing (#227)"

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -12,7 +12,4 @@
     <FileSignInfo Include="Mono.Cecil.Mdb.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Mono.Cecil.Pdb.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
-  <ItemGroup>
-    <StrongNameSignInfo Include="$(MSBuildThisFileDirectory)..\cecil.snk" PublicKeyToken="50cebf1cceb9d05e" CertificateName="CecilStrongName" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This reverts commit 59f2ded997ad3b9f08d35b387742563d27e6cad9.

It got accidentally merged into 9.0 with https://github.com/dotnet/runtime/pull/109297