### PR TITLE
Use ilasm from nuget package

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,8 +5,6 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="dotnet8" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet8/nuget/v3/index.json" />
-    <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/Test/Mono.Cecil.Tests.csproj
+++ b/Test/Mono.Cecil.Tests.csproj
@@ -7,6 +7,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
       <Version>2.10.0</Version>
     </PackageReference>
+    <PackageReference Include="runtime.$(NetCoreSdkPortableRuntimeIdentifier).Microsoft.NETCore.ILAsm">
+      <Version>9.0.4</Version>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mono.Cecil.csproj">

--- a/Test/Mono.Cecil.Tests/CompilationService.cs
+++ b/Test/Mono.Cecil.Tests/CompilationService.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using NUnit.Framework;
 
 #if NET_CORE
@@ -318,11 +319,10 @@ namespace Mono.Cecil.Tests {
 
 		public static ProcessOutput ILAsm (string source, string output)
 		{
-			var ilasm = "ilasm";
-			if (Platform.OnWindows)
-				ilasm = NetFrameworkTool ("ilasm");
+			// get ilasm from the test execution directory
+			var ilasmPath = Path.Combine (AppContext.BaseDirectory, "runtimes", RuntimeInformation.RuntimeIdentifier, "native" , Platform.OnWindows ? "ilasm.exe" : "ilasm");
 
-			return RunProcess (ilasm, "/nologo", "/dll", "/out:" + Quote (output), Quote (source));
+			return RunProcess (ilasmPath, "-nologo", "-dll", "-output=" + Quote (output), Quote (source));
 		}
 
 		static string Quote (string file)
@@ -330,6 +330,7 @@ namespace Mono.Cecil.Tests {
 			return "\"" + file + "\"";
 		}
 
+#if !NET_CORE
 		public static ProcessOutput PEVerify (string source)
 		{
 			return RunProcess (WinSdkTool ("peverify"), "/nologo", Quote (source));
@@ -338,17 +339,6 @@ namespace Mono.Cecil.Tests {
 		public static ProcessOutput PEDump (string source)
 		{
 			return RunProcess ("pedump", "--verify code,metadata", Quote (source));
-		}
-
-		static string NetFrameworkTool (string tool)
-		{
-#if NET_CORE
-			return Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Windows), "Microsoft.NET", "Framework", "v4.0.30319", tool + ".exe");
-#else
-			return Path.Combine (
-				Path.GetDirectoryName (typeof (object).Assembly.Location),
-				tool + ".exe");
-#endif
 		}
 
 		static string WinSdkTool (string tool)
@@ -381,5 +371,6 @@ namespace Mono.Cecil.Tests {
 
 			return tool;
 		}
+#endif
 	}
 }

--- a/Test/Mono.Cecil.Tests/CustomAttributesTests.cs
+++ b/Test/Mono.Cecil.Tests/CustomAttributesTests.cs
@@ -437,8 +437,6 @@ namespace Mono.Cecil.Tests {
 		[Test]
 		public void InterfaceImplementation ()
 		{
-			OnlyOnWindows (); // Mono's ilasm doesn't support .interfaceimpl
-
 			TestIL ("ca-iface-impl.il", module => {
 				var type = module.GetType ("FooType");
 				var iface = type.Interfaces.Single (i => i.InterfaceType.FullName == "IFoo");

--- a/Test/Mono.Cecil.Tests/MethodBodyTests.cs
+++ b/Test/Mono.Cecil.Tests/MethodBodyTests.cs
@@ -284,8 +284,6 @@ namespace Mono.Cecil.Tests {
 		[Test]
 		public void BranchOutsideMethod ()
 		{
-			OnlyOnWindows (); // Mono's ilasm doesn't support branching outside of method
-
 			TestIL ("branch-out.il", module => {
 				var type = module.GetType ("Foo");
 				var method = type.GetMethod ("BranchOutside");


### PR DESCRIPTION
Fixes an issue where tests would fail on recent Ubuntu CI images where Mono is no longer installed