### PR TITLE
Preserve document custom debug information

### DIFF
--- a/Mono.Cecil.Cil/PortablePdb.cs
+++ b/Mono.Cecil.Cil/PortablePdb.cs
@@ -296,7 +296,22 @@ namespace Mono.Cecil.Cil {
 				this.pdb_metadata.metadata_builder = this.module_metadata;
 
 			pdb_metadata.AddCustomDebugInformations (module);
+			ReadDocumentCustomDebugInformations ();
 			pdb_metadata.AddDocuments (module);
+		}
+
+		void ReadDocumentCustomDebugInformations ()
+		{
+			var symbol_reader = module.SymbolReader;
+			if (symbol_reader == null)
+				return;
+
+			var documents = module.Documents;
+			for (int i = 0; i < documents.Count; i++) {
+				var document = documents [i];
+				if (document.custom_infos == null)
+					document.custom_infos = symbol_reader.Read (document);
+			}
 		}
 
 		internal PortablePdbWriter (MetadataBuilder pdb_metadata, ModuleDefinition module, ImageWriter writer, Disposable<Stream> final_stream)

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2838,6 +2838,9 @@ namespace Mono.Cecil {
 		{
 			InitializeDocuments ();
 
+			for (uint rid = 1; rid <= (uint) metadata.Documents.Length; rid++)
+				GetDocument (rid);
+
 			return new Collection<Document> (metadata.Documents);
 		}
 

--- a/Mono.Cecil/AssemblyReader.cs
+++ b/Mono.Cecil/AssemblyReader.cs
@@ -2838,9 +2838,6 @@ namespace Mono.Cecil {
 		{
 			InitializeDocuments ();
 
-			for (uint rid = 1; rid <= (uint) metadata.Documents.Length; rid++)
-				GetDocument (rid);
-
 			return new Collection<Document> (metadata.Documents);
 		}
 

--- a/Test/Mono.Cecil.Tests/PortablePdbTests.cs
+++ b/Test/Mono.Cecil.Tests/PortablePdbTests.cs
@@ -548,9 +548,6 @@ namespace Mono.Cecil.Tests {
 		public void EmbeddedSource ()
 		{
 			TestModule ("embedcs.exe", module => {
-				Assert.AreEqual (3, module.Documents.Count);
-				foreach (var document in module.Documents)
-					GetSourceDebugInfo (document);
 			}, symbolReaderProvider: typeof (PortablePdbReaderProvider), symbolWriterProvider: typeof (PortablePdbWriterProvider));
 
 			TestModule ("embedcs.exe", module => {
@@ -618,6 +615,46 @@ class Program
     }
 }"), Normalize (b_src_content));
 			}, symbolReaderProvider: typeof (PortablePdbReaderProvider), symbolWriterProvider: typeof (PortablePdbWriterProvider));
+		}
+
+		[Test]
+		public void EmbeddedSourceForDocumentWithoutSequencePoints ()
+		{
+			using (var module_stream = new MemoryStream ())
+			using (var symbol_stream = new MemoryStream ()) {
+				using (var module = GetResourceModule ("embedcs.exe", new ReaderParameters {
+					SymbolReaderProvider = new PortablePdbReaderProvider (),
+				})) {
+					module.EntryPoint = null;
+					Assert.IsTrue (module.Types.Remove (module.GetType ("Program")));
+					Assert.IsTrue (module.Types.Remove (module.GetType ("B")));
+
+					module.Write (module_stream, new WriterParameters {
+						SymbolWriterProvider = new PortablePdbWriterProvider (),
+						SymbolStream = symbol_stream,
+					});
+				}
+
+				module_stream.Position = 0;
+				symbol_stream.Position = 0;
+
+				using (var module = ModuleDefinition.ReadModule (module_stream, new ReaderParameters {
+					SymbolReaderProvider = new PortablePdbReaderProvider (),
+					SymbolStream = symbol_stream,
+				})) {
+					var document = module.Documents.Single (document => document.Url.EndsWith ("b.cs", StringComparison.Ordinal));
+					var custom_infos = module.SymbolReader.Read (document);
+					Assert.IsNotNull (custom_infos);
+					var source = custom_infos.OfType<EmbeddedSourceDebugInformation> ().Single ();
+					Assert.AreEqual (Normalize (@"class B
+{
+    public static string Do()
+    {
+        return ""B::Do"";
+    }
+}"), Normalize (Encoding.UTF8.GetString (source.Content)));
+				}
+			}
 		}
 
 		static Document GetDocument (TypeDefinition type)

--- a/Test/Mono.Cecil.Tests/PortablePdbTests.cs
+++ b/Test/Mono.Cecil.Tests/PortablePdbTests.cs
@@ -548,6 +548,9 @@ namespace Mono.Cecil.Tests {
 		public void EmbeddedSource ()
 		{
 			TestModule ("embedcs.exe", module => {
+				Assert.AreEqual (3, module.Documents.Count);
+				foreach (var document in module.Documents)
+					GetSourceDebugInfo (document);
 			}, symbolReaderProvider: typeof (PortablePdbReaderProvider), symbolWriterProvider: typeof (PortablePdbWriterProvider));
 
 			TestModule ("embedcs.exe", module => {


### PR DESCRIPTION
Fixes dotnet/runtime#115145.

Portable PDB documents are preserved even when they are no longer referenced by sequence points, but their custom debug information was only loaded when resolving a referenced document. Consequently, documents left unreferenced after trimming could be written without records such as `EmbeddedSource`.

Before writing the complete document collection, load custom debug information for documents that have not already been resolved. This keeps read-only PDB usage lazy while ensuring all document records are preserved during a rewrite. Embedded-source content remains lazy and is copied from its original raw blob when written.

The regression test removes the entry point and types containing a document’s sequence points without first accessing their debug information, writes the module, and verifies the output PDB still contains that document’s embedded source.

## Testing

- `dotnet test Test/Mono.Cecil.Tests.csproj --filter FullyQualifiedName~PortablePdbTests` (36 passed)
- `dotnet test Test/Mono.Cecil.Tests.csproj` (355 passed, 3 skipped)

> [!NOTE]
> *This content was created with assistance from AI.*