### PR TITLE
Enable AOT compatibility analysis

### DIFF
--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -10,6 +10,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -1031,51 +1034,19 @@ namespace Mono.Cecil.Cil {
 
 	static class SymbolProvider {
 
-		static SR.AssemblyName GetSymbolAssemblyName (SymbolKind kind)
-		{
-			if (kind == SymbolKind.PortablePdb)
-				throw new ArgumentException ();
-
-			var suffix = GetSymbolNamespace (kind);
-
-			var cecil_name = typeof (SymbolProvider).Assembly.GetName ();
-
-			var name = new SR.AssemblyName {
-				Name = cecil_name.Name + "." + suffix,
-				Version = cecil_name.Version,
-#if NET_CORE
-				CultureName = cecil_name.CultureName,
-#else
-				CultureInfo = cecil_name.CultureInfo,
+#if NET
+		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 #endif
-			};
-
-			name.SetPublicKeyToken (cecil_name.GetPublicKeyToken ());
-
-			return name;
-		}
-
-		static Type GetSymbolType (SymbolKind kind, string fullname)
+		static Type GetSymbolType (SymbolKind kind)
 		{
-			var type = Type.GetType (fullname);
-			if (type != null)
-				return type;
-
-			var assembly_name = GetSymbolAssemblyName (kind);
-
-			type = Type.GetType (fullname + ", " + assembly_name.FullName);
-			if (type != null)
-				return type;
-
-			try {
-				var assembly = SR.Assembly.Load (assembly_name);
-				if (assembly != null)
-					return assembly.GetType (fullname);
-			} catch (FileNotFoundException) {
-			} catch (FileLoadException) {
+			switch (kind) {
+			case SymbolKind.NativePdb:
+				return Type.GetType ("Mono.Cecil.Pdb.NativePdbReaderProvider, Mono.Cecil.Pdb", false);
+			case SymbolKind.Mdb:
+				return Type.GetType ("Mono.Cecil.Mdb.MdbReaderProvider, Mono.Cecil.Mdb", false);
+			default:
+				throw new ArgumentException ();
 			}
-
-			return null;
 		}
 
 		public static ISymbolReaderProvider GetReaderProvider (SymbolKind kind)
@@ -1086,7 +1057,7 @@ namespace Mono.Cecil.Cil {
 				return new EmbeddedPortablePdbReaderProvider ();
 
 			var provider_name = GetSymbolTypeName (kind, "ReaderProvider");
-			var type = GetSymbolType (kind, provider_name);
+			var type = GetSymbolType (kind);
 			if (type == null)
 				throw new TypeLoadException ("Could not find symbol provider type " + provider_name);
 

--- a/Mono.Cecil.Cil/Symbols.cs
+++ b/Mono.Cecil.Cil/Symbols.cs
@@ -10,9 +10,7 @@
 
 using System;
 using System.Collections.Generic;
-#if NET
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -1034,9 +1032,7 @@ namespace Mono.Cecil.Cil {
 
 	static class SymbolProvider {
 
-#if NET
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-#endif
 		static Type GetSymbolType (SymbolKind kind)
 		{
 			switch (kind) {

--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(ToolsFramework);net10.0</TargetFrameworks>
+    <TargetFrameworks>$(ToolsFramework);$(NetMinimum)</TargetFrameworks>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(ToolsFramework)</TargetFramework>
+    <TargetFrameworks>$(ToolsFramework);net8.0</TargetFrameworks>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0'">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProjectInfo.cs" />

--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(ToolsFramework);net10.0</TargetFrameworks>
-    <IsAotCompatible Condition="'$(TargetFramework)' == 'net10.0'">true</IsAotCompatible>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProjectInfo.cs" />

--- a/Mono.Cecil.csproj
+++ b/Mono.Cecil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(ToolsFramework);net8.0</TargetFrameworks>
-    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0'">true</IsAotCompatible>
+    <TargetFrameworks>$(ToolsFramework);net10.0</TargetFrameworks>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net10.0'">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ProjectInfo.cs" />

--- a/Mono.Cecil/CodeAnalysis.cs
+++ b/Mono.Cecil/CodeAnalysis.cs
@@ -1,0 +1,19 @@
+#if !NET
+using System;
+
+namespace System.Diagnostics.CodeAnalysis {
+
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
+	sealed class RequiresUnreferencedCodeAttribute : Attribute {
+
+		public RequiresUnreferencedCodeAttribute (string message)
+		{
+			Message = message;
+		}
+
+		public string Message { get; }
+
+		public string Url { get; set; }
+	}
+}
+#endif

--- a/Mono.Cecil/CodeAnalysis.cs
+++ b/Mono.Cecil/CodeAnalysis.cs
@@ -3,6 +3,37 @@ using System;
 
 namespace System.Diagnostics.CodeAnalysis {
 
+	[AttributeUsage (AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+	sealed class DynamicallyAccessedMembersAttribute : Attribute {
+
+		public DynamicallyAccessedMembersAttribute (DynamicallyAccessedMemberTypes memberTypes)
+		{
+			MemberTypes = memberTypes;
+		}
+
+		public DynamicallyAccessedMemberTypes MemberTypes { get; }
+	}
+
+	[Flags]
+	enum DynamicallyAccessedMemberTypes {
+		None = 0,
+		PublicParameterlessConstructor = 0x0001,
+		PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+		NonPublicConstructors = 0x0004,
+		PublicMethods = 0x0008,
+		NonPublicMethods = 0x0010,
+		PublicFields = 0x0020,
+		NonPublicFields = 0x0040,
+		PublicNestedTypes = 0x0080,
+		NonPublicNestedTypes = 0x0100,
+		PublicProperties = 0x0200,
+		NonPublicProperties = 0x0400,
+		PublicEvents = 0x0800,
+		NonPublicEvents = 0x1000,
+		Interfaces = 0x2000,
+		All = ~None,
+	}
+
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
 	sealed class RequiresUnreferencedCodeAttribute : Attribute {
 

--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -331,9 +331,11 @@ namespace Mono.Cecil {
 			{
 				PublicKeyToken = name.GetPublicKeyToken (),
 				Culture = name.CultureInfo.Name,
-				HashAlgorithm = (AssemblyHashAlgorithm) name.HashAlgorithm,
 			};
 
+#if !NET
+			reference.HashAlgorithm = (AssemblyHashAlgorithm) name.HashAlgorithm;
+#endif
 			module.AssemblyReferences.Add (reference);
 
 			return reference;

--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -10,6 +10,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Mono.Collections.Generic;
 using SR = System.Reflection;
 
@@ -122,6 +125,9 @@ namespace Mono.Cecil {
 		}
 	}
 
+#if NET
+	[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 	public class DefaultReflectionImporter : IReflectionImporter {
 
 		readonly protected ModuleDefinition module;

--- a/Mono.Cecil/Import.cs
+++ b/Mono.Cecil/Import.cs
@@ -10,9 +10,7 @@
 
 using System;
 using System.Collections.Generic;
-#if NET
 using System.Diagnostics.CodeAnalysis;
-#endif
 using Mono.Collections.Generic;
 using SR = System.Reflection;
 
@@ -125,9 +123,7 @@ namespace Mono.Cecil {
 		}
 	}
 
-#if NET
 	[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 	public class DefaultReflectionImporter : IReflectionImporter {
 
 		readonly protected ModuleDefinition module;

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -10,6 +10,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Threading;
 using SR = System.Reflection;
@@ -383,6 +386,9 @@ namespace Mono.Cecil {
 		}
 
 		internal IReflectionImporter ReflectionImporter {
+#if NET
+			[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 			get {
 				if (reflection_importer == null)
 					Interlocked.CompareExchange (ref reflection_importer, new DefaultReflectionImporter (this), null);
@@ -803,22 +809,34 @@ namespace Mono.Cecil {
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public TypeReference Import (Type type)
 		{
 			return ImportReference (type, null);
 		}
 
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public TypeReference ImportReference (Type type)
 		{
 			return ImportReference (type, null);
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public TypeReference Import (Type type, IGenericParameterProvider context)
 		{
 			return ImportReference (type, context);
 		}
 
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public TypeReference ImportReference (Type type, IGenericParameterProvider context)
 		{
 			Mixin.CheckType (type);
@@ -828,22 +846,34 @@ namespace Mono.Cecil {
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public FieldReference Import (SR.FieldInfo field)
 		{
 			return ImportReference (field, null);
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public FieldReference Import (SR.FieldInfo field, IGenericParameterProvider context)
 		{
 			return ImportReference (field, context);
 		}
 
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public FieldReference ImportReference (SR.FieldInfo field)
 		{
 			return ImportReference (field, null);
 		}
 
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public FieldReference ImportReference (SR.FieldInfo field, IGenericParameterProvider context)
 		{
 			Mixin.CheckField (field);
@@ -853,22 +883,34 @@ namespace Mono.Cecil {
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public MethodReference Import (SR.MethodBase method)
 		{
 			return ImportReference (method, null);
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public MethodReference Import (SR.MethodBase method, IGenericParameterProvider context)
 		{
 			return ImportReference (method, context);
 		}
 
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public MethodReference ImportReference (SR.MethodBase method)
 		{
 			return ImportReference (method, null);
 		}
 
+#if NET
+		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
+#endif
 		public MethodReference ImportReference (SR.MethodBase method, IGenericParameterProvider context)
 		{
 			Mixin.CheckMethod (method);

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -10,9 +10,7 @@
 
 using System;
 using System.Collections.Generic;
-#if NET
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.IO;
 using System.Threading;
 using SR = System.Reflection;
@@ -394,9 +392,7 @@ namespace Mono.Cecil {
 		}
 
 		internal IReflectionImporter ReflectionImporter {
-#if NET
 			[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 			get {
 				if (reflection_importer == null)
 					Interlocked.CompareExchange (ref reflection_importer, new DefaultReflectionImporter (this), null);
@@ -817,34 +813,26 @@ namespace Mono.Cecil {
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public TypeReference Import (Type type)
 		{
 			return ImportReference (type, null);
 		}
 
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public TypeReference ImportReference (Type type)
 		{
 			return ImportReference (type, null);
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public TypeReference Import (Type type, IGenericParameterProvider context)
 		{
 			return ImportReference (type, context);
 		}
 
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public TypeReference ImportReference (Type type, IGenericParameterProvider context)
 		{
 			Mixin.CheckType (type);
@@ -854,34 +842,26 @@ namespace Mono.Cecil {
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public FieldReference Import (SR.FieldInfo field)
 		{
 			return ImportReference (field, null);
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public FieldReference Import (SR.FieldInfo field, IGenericParameterProvider context)
 		{
 			return ImportReference (field, context);
 		}
 
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public FieldReference ImportReference (SR.FieldInfo field)
 		{
 			return ImportReference (field, null);
 		}
 
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public FieldReference ImportReference (SR.FieldInfo field, IGenericParameterProvider context)
 		{
 			Mixin.CheckField (field);
@@ -891,34 +871,26 @@ namespace Mono.Cecil {
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public MethodReference Import (SR.MethodBase method)
 		{
 			return ImportReference (method, null);
 		}
 
 		[Obsolete ("Use ImportReference", error: false)]
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public MethodReference Import (SR.MethodBase method, IGenericParameterProvider context)
 		{
 			return ImportReference (method, context);
 		}
 
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public MethodReference ImportReference (SR.MethodBase method)
 		{
 			return ImportReference (method, null);
 		}
 
-#if NET
 		[RequiresUnreferencedCode ("The default reflection importer uses reflection to import references.")]
-#endif
 		public MethodReference ImportReference (SR.MethodBase method, IGenericParameterProvider context)
 		{
 			Mixin.CheckMethod (method);

--- a/Mono.Cecil/ModuleDefinition.cs
+++ b/Mono.Cecil/ModuleDefinition.cs
@@ -204,7 +204,9 @@ namespace Mono.Cecil {
 		bool write_symbols;
 		byte [] key_blob;
 		string key_container;
+#if !NET
 		SR.StrongNameKeyPair key_pair;
+#endif
 
 		public uint? Timestamp {
 			get { return timestamp; }
@@ -227,7 +229,11 @@ namespace Mono.Cecil {
 		}
 
 		public bool HasStrongNameKey {
+#if NET
+			get { return key_blob != null || key_container != null; }
+#else
 			get { return key_pair != null || key_blob != null || key_container != null; }
+#endif
 		}
 
 		public byte [] StrongNameKeyBlob {
@@ -240,10 +246,12 @@ namespace Mono.Cecil {
 			set { key_container = value; }
 		}
 
+#if !NET
 		public SR.StrongNameKeyPair StrongNameKeyPair {
 			get { return key_pair; }
 			set { key_pair = value; }
 		}
+#endif
 
 		public bool DeterministicMvid { get; set; }
 	}

--- a/Mono.Security.Cryptography/CryptoConvert.cs
+++ b/Mono.Security.Cryptography/CryptoConvert.cs
@@ -148,6 +148,10 @@ namespace Mono.Security.Cryptography {
 				rsa.ImportParameters (rsap);
 			}
 			catch (CryptographicException) {
+#if NET
+				if (!OperatingSystem.IsWindows ())
+					throw;
+#endif
 				// this may cause problem when this code is run under
 				// the SYSTEM identity on Windows (e.g. ASP.NET). See
 				// http://bugzilla.ximian.com/show_bug.cgi?id=77559
@@ -206,6 +210,10 @@ namespace Mono.Security.Cryptography {
 					rsa.ImportParameters (rsap);
 				}
 				catch (CryptographicException) {
+#if NET
+					if (!OperatingSystem.IsWindows ())
+						throw;
+#endif
 					// this may cause problem when this code is run under
 					// the SYSTEM identity on Windows (e.g. ASP.NET). See
 					// http://bugzilla.ximian.com/show_bug.cgi?id=77559

--- a/Mono.Security.Cryptography/CryptoService.cs
+++ b/Mono.Security.Cryptography/CryptoService.cs
@@ -12,7 +12,9 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
+#if !NET
 using System.Runtime.Serialization;
+#endif
 
 using Mono.Security.Cryptography;
 
@@ -26,7 +28,7 @@ namespace Mono.Cecil {
 
 	static class CryptoService {
 
-		static SHA1 CreateSHA1 () => new SHA1CryptoServiceProvider ();
+		static SHA1 CreateSHA1 () => SHA1.Create ();
 
 		public static byte [] GetPublicKey (WriterParameters parameters)
 		{
@@ -173,7 +175,9 @@ namespace Mono.Cecil {
 
 		public static RSA CreateRSA (this WriterParameters writer_parameters)
 		{
+#if !NET
 			byte [] key;
+#endif
 			string key_container;
 
 			if (writer_parameters.StrongNameKeyBlob != null)
@@ -181,8 +185,16 @@ namespace Mono.Cecil {
 
 			if (writer_parameters.StrongNameKeyContainer != null)
 				key_container = writer_parameters.StrongNameKeyContainer;
+#if NET
+			else
+				throw new InvalidOperationException ();
+
+			if (!OperatingSystem.IsWindows ())
+				throw new PlatformNotSupportedException ();
+#else
 			else if (!TryGetKeyContainer (writer_parameters.StrongNameKeyPair, out key, out key_container))
 				return CryptoConvert.FromCapiKeyBlob (key);
+#endif
 
 			var parameters = new CspParameters {
 				Flags = CspProviderFlags.UseMachineKeyStore,
@@ -193,6 +205,7 @@ namespace Mono.Cecil {
 			return new RSACryptoServiceProvider (parameters);
 		}
 
+#if !NET
 		static bool TryGetKeyContainer (ISerializable key_pair, out byte [] key, out string key_container)
 		{
 			var info = new SerializationInfo (typeof (StrongNameKeyPair), new FormatterConverter ());
@@ -202,5 +215,6 @@ namespace Mono.Cecil {
 			key_container = info.GetString ("_keyPairContainer");
 			return key_container != null;
 		}
+#endif
 	}
 }

--- a/Mono.Security.Cryptography/CryptoService.cs
+++ b/Mono.Security.Cryptography/CryptoService.cs
@@ -206,6 +206,7 @@ namespace Mono.Cecil {
 		}
 
 #if !NET
+		// StrongNameKeyPair and BinaryFormatter are not support in .NET Core
 		static bool TryGetKeyContainer (ISerializable key_pair, out byte [] key, out string key_container)
 		{
 			var info = new SerializationInfo (typeof (StrongNameKeyPair), new FormatterConverter ());


### PR DESCRIPTION
Enable AOT compatibility analysis for Cecil by adding a `net10.0` analyzer target with `IsAotCompatible=true`.

- Use constant assembly-qualified names for optional PDB/MDB providers so trimming can preserve their constructors.
- Mark reflection-based import APIs with `RequiresUnreferencedCode`.
- Polyfill `RequiresUnreferencedCodeAttribute`, `DynamicallyAccessedMembersAttribute`, and `DynamicallyAccessedMemberTypes` so annotations are also shipped in the `netstandard2.0` assembly.
- Replace or isolate obsolete and Windows-only APIs on modern .NET.
- Preserve the existing `netstandard2.0` product target.

Validation:
- `dotnet build Mono.Cecil.sln --no-incremental --verbosity:minimal`
- Zero warnings and errors.