### PR TITLE
Fix WriteCompressedInt32 endianness on big-endian hosts

### DIFF
--- a/Mono.Cecil.PE/ByteBuffer.cs
+++ b/Mono.Cecil.PE/ByteBuffer.cs
@@ -269,11 +269,13 @@ namespace Mono.Cecil.PE {
 				} else if ((value & ~b13) == (signMask & ~b13)) {
 					int n = ((value & b13) << 1) | (signMask & 1);
 					ushort val = (ushort)(0x8000 | n);
-					WriteUInt16 (BitConverter.IsLittleEndian ? ReverseEndianness (val) : val);
+					// WriteUInt16 is always little-endian; compressed ints must be big-endian.
+					WriteUInt16 (ReverseEndianness (val));
 				} else if ((value & ~b28) == (signMask & ~b28)) {
 					int n = ((value & b28) << 1) | (signMask & 1);
 					uint val = 0xc0000000 | (uint)n;
-					WriteUInt32 (BitConverter.IsLittleEndian ? ReverseEndianness (val) : val);
+					// WriteUInt32 is always little-endian; compressed ints must be big-endian.
+					WriteUInt32 (ReverseEndianness (val));
 				} else {
 					throw new ArgumentOutOfRangeException ("value", "valid range is -2^28 to 2^28 -1");
 				}

--- a/Test/Mono.Cecil.Tests/ByteBufferTests.cs
+++ b/Test/Mono.Cecil.Tests/ByteBufferTests.cs
@@ -13,6 +13,24 @@ namespace Mono.Cecil.Tests {
 			Assert.AreEqual (-9076, result);
 		}
 
+		// Round-trip tests pass on big-endian even with swapped bytes.
+		// Assert the ECMA-335 II.23.2 encoding (always big-endian in the blob).
+		[Test]
+		public void CompressedInt32BytesAreBigEndian ()
+		{
+			AssertCompressedInt32Bytes (-100, 0xBF, 0x39);
+			AssertCompressedInt32Bytes (-9076, 0xDF, 0xFF, 0xB9, 0x19);
+		}
+
+		static void AssertCompressedInt32Bytes (int value, params byte [] expected)
+		{
+			var testee = new ByteBuffer ();
+			testee.WriteCompressedInt32 (value);
+			Assert.AreEqual (expected.Length, testee.length);
+			for (int i = 0; i < expected.Length; i++)
+				Assert.AreEqual (expected [i], testee.buffer [i]);
+		}
+
 		// Round-trips WriteCompressedInt32/ReadCompressedInt32 across every encoding-width
 		// boundary of the ECMA-335 compressed signed integer format (1/2/4-byte forms)
 		[TestCase (0)]


### PR DESCRIPTION
Cecil’s WriteUInt16/WriteUInt32 are always little-endian. WriteCompressedInt32 copied SRM’s IsLittleEndian check, so on big-endian it writes swapped compressed ints into portable PDBs.

That landed in dotnet/cecil via [#505](https://github.com/dotnet/cecil/pull/505) (608fac6, originally [jbevain/cecil#958](https://github.com/jbevain/cecil/pull/958)) and flowed into the VMR in [dotnet/dotnet#8250](https://github.com/dotnet/dotnet/pull/8250. Native s390x VMR Mono then fails in ILLink while trimming System.Runtime (IL1012, ArgumentNullException / document).

Always ReverseEndianness before those writes. Round-trip tests do not catch this on little-endian, the new test asserts spec bytes (-100 → BF39, -9076 → DFFFB919).

cc: @tmds